### PR TITLE
Adding the mounts in the data lake origins as partitions

### DIFF
--- a/k8s/pvs/pv-k8s1-pb10-ultralight-org-persistent.yaml
+++ b/k8s/pvs/pv-k8s1-pb10-ultralight-org-persistent.yaml
@@ -1,0 +1,73 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-k8s1-pb10-ultralight-org-persistent-1
+  namespace: cms-admin
+spec:
+  capacity:
+    storage: 10Gi
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: local-persistent-1
+  local:
+    path: /data1
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - k8s1-pb10.ultralight.org
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-k8s1-pb10-ultralight-org-persistent-1
+  namespace: cms-admin
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: local-persistent-1
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name:	pv-k8s1-pb10-ultralight-org-persistent-8
+  namespace: cms-admin
+spec:
+  capacity:
+    storage: 10Gi
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: local-persistent-8
+  local:
+    path: /data8
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - k8s1-pb10.ultralight.org
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name:	pvc-k8s1-pb10-ultralight-org-persistent-8
+  namespace: cms-admin
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: local-persistent-8

--- a/k8s/pvs/pv-xrootd-data-lake-origin-1-t2-ucsd-edu-persistent-1.yaml
+++ b/k8s/pvs/pv-xrootd-data-lake-origin-1-t2-ucsd-edu-persistent-1.yaml
@@ -1,0 +1,443 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-xrootd-data-lake-origin-1-t2-ucsd-edu-persistent-1
+  namespace: cms-admin
+spec:
+  capacity:
+    storage: 10Gi
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: local-persistent-1
+  local:
+    path: /data1
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - xrootd-data-lake-origin-1.t2.ucsd.edu
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-xrootd-data-lake-origin-1-t2-ucsd-edu-persistent-1
+  namespace: cms-admin
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: local-persistent-2
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-xrootd-data-lake-origin-1-t2-ucsd-edu-persistent-2
+  namespace: cms-admin
+spec:
+  capacity:
+    storage: 10Gi
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: local-persistent-2
+  local:
+    path: /data2
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - xrootd-data-lake-origin-1.t2.ucsd.edu
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-xrootd-data-lake-origin-1-t2-ucsd-edu-persistent-2
+  namespace: cms-admin
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: local-persistent-2
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-xrootd-data-lake-origin-1-t2-ucsd-edu-persistent-3
+  namespace: cms-admin
+spec:
+  capacity:
+    storage: 10Gi
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: local-persistent-3
+  local:
+    path: /data3
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - xrootd-data-lake-origin-1.t2.ucsd.edu
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-xrootd-data-lake-origin-1-t2-ucsd-edu-persistent-3
+  namespace: cms-admin
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: local-persistent-3
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-xrootd-data-lake-origin-1-t2-ucsd-edu-persistent-4
+  namespace: cms-admin
+spec:
+  capacity:
+    storage: 10Gi
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: local-persistent-4
+  local:
+    path: /data4
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - xrootd-data-lake-origin-1.t2.ucsd.edu
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-xrootd-data-lake-origin-1-t2-ucsd-edu-persistent-4
+  namespace: cms-admin
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: local-persistent-4
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-xrootd-data-lake-origin-1-t2-ucsd-edu-persistent-5
+  namespace: cms-admin
+spec:
+  capacity:
+    storage: 10Gi
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: local-persistent-5
+  local:
+    path: /data5
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - xrootd-data-lake-origin-1.t2.ucsd.edu
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-xrootd-data-lake-origin-1-t2-ucsd-edu-persistent-5
+  namespace: cms-admin
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: local-persistent-5
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-xrootd-data-lake-origin-1-t2-ucsd-edu-persistent-6
+  namespace: cms-admin
+spec:
+  capacity:
+    storage: 10Gi
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: local-persistent-6
+  local:
+    path: /data6
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - xrootd-data-lake-origin-1.t2.ucsd.edu
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-xrootd-data-lake-origin-1-t2-ucsd-edu-persistent-6
+  namespace: cms-admin
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: local-persistent-6
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-xrootd-data-lake-origin-1-t2-ucsd-edu-persistent-7
+  namespace: cms-admin
+spec:
+  capacity:
+    storage: 10Gi
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: local-persistent-7
+  local:
+    path: /data7
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - xrootd-data-lake-origin-1.t2.ucsd.edu
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-xrootd-data-lake-origin-1-t2-ucsd-edu-persistent-7
+  namespace: cms-admin
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: local-persistent-7
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-xrootd-data-lake-origin-1-t2-ucsd-edu-persistent-8
+  namespace: cms-admin
+spec:
+  capacity:
+    storage: 10Gi
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: local-persistent-8
+  local:
+    path: /data3
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - xrootd-data-lake-origin-1.t2.ucsd.edu
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-xrootd-data-lake-origin-1-t2-ucsd-edu-persistent-8
+  namespace: cms-admin
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: local-persistent-8
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-xrootd-data-lake-origin-1-t2-ucsd-edu-persistent-9
+  namespace: cms-admin
+spec:
+  capacity:
+    storage: 10Gi
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: local-persistent-9
+  local:
+    path: /data9
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - xrootd-data-lake-origin-1.t2.ucsd.edu
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-xrootd-data-lake-origin-1-t2-ucsd-edu-persistent-9
+  namespace: cms-admin
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: local-persistent-9
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-xrootd-data-lake-origin-1-t2-ucsd-edu-persistent-10
+  namespace: cms-admin
+spec:
+  capacity:
+    storage: 10Gi
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: local-persistent-10
+  local:
+    path: /data10
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - xrootd-data-lake-origin-1.t2.ucsd.edu
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-xrootd-data-lake-origin-1-t2-ucsd-edu-persistent-10
+  namespace: cms-admin
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: local-persistent-10
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-xrootd-data-lake-origin-1-t2-ucsd-edu-persistent-11
+  namespace: cms-admin
+spec:
+  capacity:
+    storage: 10Gi
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: local-persistent-11
+  local:
+    path: /data11
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - xrootd-data-lake-origin-1.t2.ucsd.edu
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-xrootd-data-lake-origin-1-t2-ucsd-edu-persistent-11
+  namespace: cms-admin
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: local-persistent-11
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-xrootd-data-lake-origin-1-t2-ucsd-edu-persistent-12
+  namespace: cms-admin
+spec:
+  capacity:
+    storage: 10Gi
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: local-persistent-12
+  local:
+    path: /data12
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - xrootd-data-lake-origin-1.t2.ucsd.edu
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-xrootd-data-lake-origin-1-t2-ucsd-edu-persistent-12
+  namespace: cms-admin
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: local-persistent-12


### PR DESCRIPTION
This request creates the PVC for the two hosts for the data lake origin:

* k8s1-pb10.ultralight.org
* xrootd-data-lake-origin-1.t2.ucsd.edu